### PR TITLE
Fixed connection bug

### DIFF
--- a/Melberg.Infrastructure.Redis/DependencyModule.cs
+++ b/Melberg.Infrastructure.Redis/DependencyModule.cs
@@ -16,7 +16,7 @@ namespace Melberg.Infrastructure.Redis
 
             catalog.AddTransient<TFrom, TTo>();
 
-            catalog.AddTransient<TContext, TContext>();
+            catalog.AddSingleton<TContext, TContext>();
         }
     }
 }

--- a/Melberg.Infrastructure.Redis/RedisContext.cs
+++ b/Melberg.Infrastructure.Redis/RedisContext.cs
@@ -9,9 +9,11 @@ namespace Melberg.Infrastructure.Redis
         public RedisContext(IRedisConfigurationProvider provider)
         {
             _connection = ConnectionMultiplexer.Connect(provider.GetConnectionString(this.GetType().Name));
+            DB = _connection.GetDatabase();
+
         }
 
-        public IDatabaseAsync DB => _connection.GetDatabase();
 
+        public IDatabaseAsync DB{ get; private set;}
     }
 }


### PR DESCRIPTION
Changing the dependency registry of the redis context from transient to singleton lets the system use the current connection for all injections